### PR TITLE
Feature/ble

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BleCommC (0.2.1)
+  - BleCommC (0.2.2)
 
 DEPENDENCIES:
   - BleCommC (from `../`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  BleCommC: e6eba8a35c53bd17c1c4505d380b1da3f09032c4
+  BleCommC: 74b94f5b4d46583249d121d88a73c4093b7484db
 
 COCOAPODS: 0.39.0

--- a/Pod/Classes/BLE.h
+++ b/Pod/Classes/BLE.h
@@ -48,9 +48,9 @@
 @interface DataHandler : NSObject {
 }
 
-@property id<BleComm> bleComm;
-@property id<CommDelegate> commDelegate;
-@property (nonatomic) int packetSize;
+@property (nonatomic, weak) id <BleComm> bleComm;
+@property (nonatomic, weak) id <CommDelegate> commDelegate;
+@property (nonatomic, assign) int packetSize;
 
 -(id) initWith:(id<BleComm>) bleComm commDelegate:(id<CommDelegate>) commDelegate packetSize:(int) packetSize;
 -(void) onConnectionFinalized;
@@ -83,31 +83,36 @@
 @property (strong, nonatomic) NSString *hardwareRevision;
 @property (strong, nonatomic) NSString *firmwareRevision;
 @property (strong, nonatomic) NSString *softwareRevision;
+@property (strong, nonatomic) NSNumber *RSSI;
+@property (assign, nonatomic) NSInteger connectionAttempts;
 
 @end
 
-@interface BLEScan : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate> {
-    
-}
+@interface BLEScan : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate>
 
 @property (strong, nonatomic) CBPeripheral *currentPeripheral;
-@property (strong, nonatomic) BLEOBject *currentBLE;
 @property (strong, nonatomic) NSMutableArray *peripherals;
 @property (strong, nonatomic) CBCentralManager *centralManager;
-@property (strong, nonatomic) CBUUID* sUUID;
-@property (strong, nonatomic) CBUUID* iUUID;
-@property (nonatomic,weak) id <ScanDelegate> delegate;
+@property (strong, nonatomic) CBUUID *sUUID;
+@property (strong, nonatomic) CBUUID *iUUID;
+@property (strong, nonatomic) NSTimer *timer;
+@property (copy, nonatomic) NSString *serialNumber;
+@property (copy, nonatomic) NSString *modelNumber;
+@property (weak, nonatomic) id <ScanDelegate> delegate;
 
--(void) doInit;
--(int) doScan:(int) timeout;
--(int) doScanWithDeviceInfo:(int) timeout;
+- (void)doInit;
 
--(void) scanTimer:(NSTimer *)timer;
+- (int)doScan:(int)timeout;
+
+- (int)doScanWithDeviceInfo:(int)timeout;
+
+- (int)doScanWithTimeout:(NSInteger)timeout withModelNumber:(NSString *)modelNumber andSerialNumber:(NSString *)serialNumber;
+
+- (void)scanTimer:(NSTimer *)timer;
 
 @end
 
-@interface DefaultBLEComm : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate, BleComm> {
-}
+@interface DefaultBLEComm : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate, BleComm>
 
 @property (strong, nonatomic) CBCentralManager *centralManager;
 @property (strong, nonatomic) CBPeripheral *currentPeripheral;
@@ -119,7 +124,7 @@
 @property (strong, nonatomic) CBUUID* fUUID;
 @property (nonatomic) int packetSize;
 @property (strong, nonatomic) NSUUID* deviceId;
-@property (nonatomic,weak) id <CommDelegate> delegate;
+@property (nonatomic, weak) id <CommDelegate> delegate;
 @property (strong, nonatomic) NSMutableArray *features;
 @property (strong, nonatomic) DataHandler* dataHandler;
 

--- a/Pod/Classes/BLE.h
+++ b/Pod/Classes/BLE.h
@@ -98,6 +98,7 @@
 @property (strong, nonatomic) NSTimer *timer;
 @property (copy, nonatomic) NSString *serialNumber;
 @property (copy, nonatomic) NSString *modelNumber;
+@property (assign, nonatomic) NSInteger connectionAttempts;
 @property (weak, nonatomic) id <ScanDelegate> delegate;
 
 - (void)doInit;

--- a/Pod/Classes/BLE.m
+++ b/Pod/Classes/BLE.m
@@ -48,10 +48,9 @@ bool withDeviceInfo = FALSE;
         return -1;
     }
     
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:(float)timeout target:self selector:@selector(scanTimer:) userInfo:nil repeats:NO];
-    
     if (self.sUUID) {
         [self.centralManager scanForPeripheralsWithServices:[NSArray arrayWithObject:self.sUUID] options:nil];
+        self.timer = [NSTimer scheduledTimerWithTimeInterval:(float)timeout target:self selector:@selector(scanTimer:) userInfo:nil repeats:NO];
     } else {
         return -1;
     }


### PR DESCRIPTION
When multiple devices were detected via the scan, the wait for the user became too much. 

I added two properties to the BLEObject, namely RSSI and connectionAttempts. I sort the peripheral array by RSSI which puts the closest devices first for scanning. In certain circumstances, it would attempt to connect to the same device multiple times. It now limits each device to 3 connection attempts which significantly reduces waiting time.
When gathering device info occurs, the process stops when it finds the appropriate object and passes it back. Again, this decreases the time in which the user has to wait in order to connect.
